### PR TITLE
Correct the spelling of Xcode in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ ibtool original.xib --compile original.xib.bin
 
 ## DEMO
 
-* Open the included XCode project (remember to get some pods: pod install).
+* Open the included Xcode project (remember to get some pods: pod install).
 
 * Run it once. If you hit "Show Popover" BEFORE hitting "Load remote nibs", you'll use the original .xib files.
 


### PR DESCRIPTION

This pull request corrects the spelling of **Xcode** :sweat_smile:
https://developer.apple.com/xcode/

Created with [`xcode-readme`](https://github.com/dkhamsing/xcode-readme).
